### PR TITLE
Revert resolve content changes in SharedStreams 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.9.5_preview / 2022-08-09
+
+- Address content resolving bug in SharedStreams
+
 ## 0.9.4_preview / 2022-07-30
 
 - Add testing for Streams and BaseClient

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: This library is an AVEVA Data Hub targeted version of the ocs_sample_library_preview. The ocs_sample_library_preview library is being deprecated and this library should be used moving forward. |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
-**Version:** 0.9.4_preview
+**Version:** 0.9.5_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=4674&branchName=main)
 
@@ -23,14 +23,17 @@ Other language libraries and samples are available on [GitHub](https://github.co
 
 ## Testing
 
-The library is tested using PyTest. To test locally, navigate to the Tests directory and install PyTest. Then run the test classes by executing 
+The library is tested using PyTest. To test locally, make sure that PyTest is installed, then navigate to the Tests directory and run the test classes by executing 
 ```
 python -m pytest {testclass} 
 ```
 
 where {testclass} is the name of a test class, for example ./test_baseclient.py. 
 
-Optionally, rename the appsettings.placeholder.json file to appsettings.json and populate the fields to enable running end to end tests. Note: This file is included in the gitignore and will not be pushed to a remote repository. 
+Optionally to run end to end tests, rename the appsettings.placeholder.json file to appsettings.json and populate the fields, (This file is included in the gitignore and will not be pushed to a remote repository), then run 
+```
+python -m pytest {testclass} --e2e True
+```
 
 ## Logging
 

--- a/adh_sample_library_preview/BaseClient.py
+++ b/adh_sample_library_preview/BaseClient.py
@@ -5,8 +5,6 @@ import requests
 from .AbstractBaseClient import AbstractBaseClient
 from .Authentication import Authentication
 from .SdsError import SdsError
-from .SDS.SdsResultPage import SdsResultPage
-from .SDS.SdsStream import SdsStream
 
 
 class BaseClient(AbstractBaseClient):

--- a/adh_sample_library_preview/SharedStreams.py
+++ b/adh_sample_library_preview/SharedStreams.py
@@ -8,7 +8,6 @@ from .SDS.SdsStream import SdsStream
 from .SDS.SdsResolvedStream import SdsResolvedStream
 from .SDS.SdsType import SdsType
 from .PatchableSecurable import PatchableSecurable
-
 from .Streams import Streams
 
 class SharedStreams(PatchableSecurable, object):
@@ -102,7 +101,11 @@ class SharedStreams(PatchableSecurable, object):
         self.__base_client.checkResponse(
             response, 'Failed to get all SdsStreams.')
         
-        return self.__base_client.resolveStreamsContent(response=response)
+        content = response.json()
+        results: list[SdsStream] = []
+        for item in content:
+            results.append(SdsStream.fromJson(item))
+        return results
 
     # The following section provides functionality to interact with Data
     #  We assume the value(s) passed follow the Sds object patterns
@@ -459,7 +462,13 @@ class SharedStreams(PatchableSecurable, object):
         if value_class is None:
             return content
 
-        return self.__base_client.resolveBulkContent(response=response, value_class=value_class)
+        values = []
+        for valueArray in content:
+            valuesInside = []
+            for value in valueArray:
+                valuesInside.append(value_class.fromJson(value))
+            values.append(valuesInside)
+        return values
 
     # private methods
 

--- a/adh_sample_library_preview/Streams.py
+++ b/adh_sample_library_preview/Streams.py
@@ -353,7 +353,6 @@ class Streams(PatchableSecurable, object):
         self.__base_client.checkResponse(
             response, f'Failed to get value for SdsStream: {url}.')
 
-
         return ValueContent(response=response, value_class=value_class).resolve()
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='adh_sample_library_preview',
-    version='0.9.4_preview',
+    version='0.9.5_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='samples@osisoft.com',


### PR DESCRIPTION
SharedStreams is using baseClient content resolving methods that no longer exist, this reverts that change back.